### PR TITLE
Add Python 3.12 to CI matrix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Monitoring",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]


### PR DESCRIPTION
## Summary
- Adds Python 3.12 to the CI test matrix

Closes #1545

## Testing
- [x] CI should pass on all Python versions