### PR TITLE
Draft: gRPC transport for OTLP

### DIFF
--- a/src/acme_sdk/exporters/grpc.py
+++ b/src/acme_sdk/exporters/grpc.py
@@ -1,0 +1,51 @@
+"""gRPC transport for the OTLP exporter (WIP)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional, Sequence
+
+from acme_sdk.models import Span
+
+logger = logging.getLogger(__name__)
+
+
+class GRPCExporter:
+    """Export telemetry data using OTLP over gRPC.
+
+    This exporter provides lower-latency export compared to HTTP,
+    suitable for high-throughput production workloads.
+
+    NOTE: This is a work in progress. The gRPC transport is not yet
+    fully implemented.
+
+    Args:
+        endpoint: gRPC endpoint address (host:port).
+        credentials: Optional gRPC channel credentials.
+        compression: Whether to use gzip compression.
+        timeout: RPC deadline in seconds.
+    """
+
+    def __init__(
+        self,
+        endpoint: str = "localhost:4317",
+        credentials: Optional[Any] = None,
+        compression: bool = True,
+        timeout: float = 30.0,
+    ) -> None:
+        self._endpoint = endpoint
+        self._compression = compression
+        self._timeout = timeout
+
+        # TODO: Initialize gRPC channel
+        # try:
+        #     import grpc
+        #     self._channel = grpc.insecure_channel(endpoint)
+        # except ImportError:
+        #     raise ImportError("grpcio is required for gRPC transport")
+
+        logger.warning("GRPCExporter is not yet fully implemented")
+
+    def export(self, spans: Sequence[Span]) -> None:
+        """Export spans via gRPC (not yet implemented)."""
+        raise NotImplementedError("gRPC export is not yet implemented")


### PR DESCRIPTION
## Summary
Work in progress: Adding gRPC transport option for the OTLP exporter.

Refs #1543

## Status
- [x] Skeleton exporter class
- [ ] gRPC channel initialization
- [ ] Proto compilation
- [ ] Span serialization to proto
- [ ] Retry/backoff for gRPC
- [ ] Tests
- [ ] Documentation